### PR TITLE
upgrade terrajux to 0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,11 @@ RUN \
   curl \
     --location \
     --remote-name \
-    https://github.com/rhenning/terrajux/releases/download/v0.2.0/terrajux_0.2.0_linux_amd64.tar.gz && \
-  tar zxvf terrajux_0.2.0_linux_amd64.tar.gz && \
-  cp terrajux_0.2.0_linux_amd64/terrajux /usr/bin && \
-  rm -rf terrajux_0.2.0_linux_amd64 && \
-  rm terrajux_0.2.0_linux_amd64.tar.gz
+    https://github.com/rhenning/terrajux/releases/download/v0.3.0/terrajux_0.3.0_linux_amd64.tar.gz && \
+  tar zxvf terrajux_0.3.0_linux_amd64.tar.gz && \
+  cp terrajux_0.3.0_linux_amd64/terrajux /usr/bin && \
+  rm -rf terrajux_0.3.0_linux_amd64 && \
+  rm terrajux_0.3.0_linux_amd64.tar.gz
 
 COPY VERSION /VERSION
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The most relevant terrajux changes are here:
https://github.com/rhenning/terrajux/pull/19

Signed-off-by: Mike Ball <mikedball@gmail.com>